### PR TITLE
Probably fix bug with 5, 4 segments

### DIFF
--- a/G213Colors.py
+++ b/G213Colors.py
@@ -50,6 +50,9 @@ breatheCommand = {"G213": "11ff0c3a0002{}{}006400000000000000",
 cycleCommand   = {"G213": "11ff0c3a0003ffffff0000{}64000000000000",
                   "G203": "11ff0e3c00020000000000{}64000000000000"}  # speed; brightness
 
+# not believe that this is exactly "reset"
+resetCommand   = "11ff0c0c00000000000000000000000000000000"
+
 device         = ""               # device resource
 productName    = ""               # e.g. G213, G203
 isDetached     = {"G213": False,  # If kernel driver needs to be reattached
@@ -83,6 +86,9 @@ def disconnectG():
         device.attach_kernel_driver(wIndex)
         print("Disconnected " + productName)
 
+def receiveData():
+    device.read(0x82, 64)
+
 def sendData(data):
     global productName
     print("Send data to " + productName)
@@ -94,7 +100,16 @@ def sendData(data):
 
 def sendColorCommand(colorHex, field=0):
     global productName
+
+    if productName == "G213":
+        device.set_configuration()
+        sendData(resetCommand)
+        receiveData()
+
     sendData(colorCommand[productName].format(str(format(field, '02x')), colorHex))
+
+    if productName == "G213":
+        receiveData()
 
 def sendBreatheCommand(colorHex, speed):
     global productName

--- a/G213Colors.py
+++ b/G213Colors.py
@@ -87,7 +87,7 @@ def disconnectG():
         print("Disconnected " + productName)
 
 def receiveData():
-    device.read(0x82, 64)
+    device.read(0x81, 64)
 
 def sendData(data):
     global productName

--- a/G213Colors.py
+++ b/G213Colors.py
@@ -28,6 +28,7 @@ import sys
 import usb.core
 import usb.util
 import binascii
+import platform
 
 
 standardColor  = 'ffb4aa'         # Standard color, i found this color to produce a white color on my G213
@@ -98,7 +99,7 @@ def sendData(data):
 def sendColorCommand(colorHex, field=0):
     global productName
 
-    if productName == "G213":
+    if productName == "G213" and platform.system() == "Windows":
         device.set_configuration()
 
     sendData(colorCommand[productName].format(str(format(field, '02x')), colorHex))

--- a/G213Colors.py
+++ b/G213Colors.py
@@ -50,9 +50,6 @@ breatheCommand = {"G213": "11ff0c3a0002{}{}006400000000000000",
 cycleCommand   = {"G213": "11ff0c3a0003ffffff0000{}64000000000000",
                   "G203": "11ff0e3c00020000000000{}64000000000000"}  # speed; brightness
 
-# not believe that this is exactly "reset"
-resetCommand   = "11ff0c0c00000000000000000000000000000000"
-
 device         = ""               # device resource
 productName    = ""               # e.g. G213, G203
 isDetached     = {"G213": False,  # If kernel driver needs to be reattached
@@ -87,7 +84,7 @@ def disconnectG():
         print("Disconnected " + productName)
 
 def receiveData():
-    device.read(0x81, 64)
+    device.read(0x82, 64)
 
 def sendData(data):
     global productName
@@ -103,8 +100,6 @@ def sendColorCommand(colorHex, field=0):
 
     if productName == "G213":
         device.set_configuration()
-        sendData(resetCommand)
-        receiveData()
 
     sendData(colorCommand[productName].format(str(format(field, '02x')), colorHex))
 

--- a/G213Colors.py
+++ b/G213Colors.py
@@ -99,9 +99,6 @@ def sendData(data):
 def sendColorCommand(colorHex, field=0):
     global productName
 
-    if productName == "G213" and platform.system() == "Windows":
-        device.set_configuration()
-
     sendData(colorCommand[productName].format(str(format(field, '02x')), colorHex))
 
     if productName == "G213":

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import G213Colors
 import gi
 import sys
+import platform
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 from time import sleep
@@ -64,7 +65,7 @@ class Window(Gtk.Window):
             print(i)
             print(self.btnGetHex(self.segmentColorBtns[i-1]))
             myG.sendColorCommand(self.btnGetHex(self.segmentColorBtns[i -1]), i)
-            data += myG.colorCommand[product].format(str(format(i, '02x')), self.btnGetHex(self.segmentColorBtns[i -1])) + ","
+            data += myG.colorCommand[product].format(str(format(i, '02x')), self.btnGetHex(self.segmentColorBtns[i -1])) + "\n"
             sleep(0.01)
         myG.disconnectG()
         if product == "G213":
@@ -164,12 +165,22 @@ class Window(Gtk.Window):
 if "-t" in option:
     myG = G213Colors
     myG.connectG("G213")
-    file = open(myG.confFile, "r")
-    commands = file.readline().split(',')
-    for command in commands:
-        print(command)
-        myG.sendData(command)
-        sleep(0.01)
+
+    with open(myG.confFile, "r") as file:
+
+        for command in file:
+            print(command)
+            command = command.strip()
+            if command and "," not in command:
+                if platform.system() == "Windows":
+                    myG.device.set_configuration()
+                myG.sendData(command)
+                myG.receiveData()
+                sleep(0.01)
+
+            if "," in command:
+                print("\",\" is not supported in the config file.")
+                print("If you apply a color scheme with segments, please re-apply it or replace all \",\" with new lines in \"/etc/G213Colors.conf\".")
 
     myG.disconnectG()
     sys.exit(0)

--- a/main.py
+++ b/main.py
@@ -172,8 +172,6 @@ if "-t" in option:
             print(command)
             command = command.strip()
             if command and "," not in command:
-                if platform.system() == "Windows":
-                    myG.device.set_configuration()
                 myG.sendData(command)
                 myG.receiveData()
                 sleep(0.01)


### PR DESCRIPTION
Hi!  

I use G213Colors (without gui) on Windows, but encountered a problem. I can chanage color only one times after reboot. I additionally reverse engineering G213 and I solved the the problem. I'm find one more command and named it "reset", also I noticed that offical softaware recive data and I too add this in code. Now all segments work fine on Windows, but I dont have an opportunity test it in Linux. Сould you check its work?