### PR TITLE
Using Python3 by default

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import G213Colors


### PR DESCRIPTION
Bug Fix: Python2 is no longer distributed by default and not even linked on some distros (like Ubuntu 20.04).